### PR TITLE
Remove `KGradientSelector::setStops`

### DIFF
--- a/cmd/genbindings/config-allowlist.go
+++ b/cmd/genbindings/config-allowlist.go
@@ -352,7 +352,7 @@ func AllowMethod(className string, mm CppMethod) error {
 		return ErrTooComplex // Qt 6.8: qdbuspendingreply.h, templated method
 	}
 
-	if className == "QGradient" && mm.MethodName == "setStops" {
+	if (className == "KGradientSelector" || className == "QGradient") && mm.MethodName == "setStops" {
 		return ErrTooComplex // Qt 6.4: undefined symbol error during compilation
 	}
 

--- a/include/extras-kwidgetsaddons/libkselector.h
+++ b/include/extras-kwidgetsaddons/libkselector.h
@@ -267,7 +267,6 @@ QMetaObject* KGradientSelector_MetaObject(const KGradientSelector* self);
 void* KGradientSelector_Metacast(KGradientSelector* self, const char* param1);
 int KGradientSelector_Metacall(KGradientSelector* self, int param1, int param2, void** param3);
 libqt_string KGradientSelector_Tr(const char* s);
-void KGradientSelector_SetStops(KGradientSelector* self, const libqt_list /* of libqt_pair  tuple of double and QColor*  */ stops);
 libqt_list /* of libqt_pair  tuple of double and QColor*  */ KGradientSelector_Stops(const KGradientSelector* self);
 void KGradientSelector_SetColors(KGradientSelector* self, const QColor* col1, const QColor* col2);
 void KGradientSelector_SetText(KGradientSelector* self, const libqt_string t1, const libqt_string t2);

--- a/include/extras-kwidgetsaddons/libkselector.zig
+++ b/include/extras-kwidgetsaddons/libkselector.zig
@@ -5641,17 +5641,6 @@ pub const kgradientselector = struct {
         return _ret;
     }
 
-    /// [Qt documentation](https://api.kde.org/kgradientselector.html#setStops)
-    ///
-    /// ``` self: QtC.KGradientSelector, stops: []struct_f64_qtcqcolor ```
-    pub fn SetStops(self: ?*anyopaque, stops: []struct_f64_qtcqcolor) void {
-        const stops_list = qtc.libqt_list{
-            .len = stops.len,
-            .data = stops.ptr,
-        };
-        qtc.KGradientSelector_SetStops(@ptrCast(self), stops_list);
-    }
-
     /// [Qt documentation](https://api.kde.org/kgradientselector.html#stops)
     ///
     /// ``` self: QtC.KGradientSelector, allocator: std.mem.Allocator ```

--- a/src/extras-kwidgetsaddons/libkselector.cpp
+++ b/src/extras-kwidgetsaddons/libkselector.cpp
@@ -1981,21 +1981,6 @@ libqt_string KGradientSelector_Tr(const char* s) {
     return _str;
 }
 
-void KGradientSelector_SetStops(KGradientSelector* self, const libqt_list /* of libqt_pair  tuple of double and QColor*  */ stops) {
-    QList<QPair<double, QColor>> stops_QList;
-    stops_QList.reserve(stops.len);
-    libqt_pair /* tuple of double and QColor* */* stops_arr = static_cast<libqt_pair /* tuple of double and QColor* */*>(stops.data);
-    for (size_t i = 0; i < stops.len; ++i) {
-        QPair<double, QColor> stops_arr_i_QPair;
-        double* stops_arr_i_first = static_cast<double*>(stops_arr[i].first);
-        QColor** stops_arr_i_second = static_cast<QColor**>(stops_arr[i].second);
-        stops_arr_i_QPair.first = static_cast<double>(stops_arr_i_first[0]);
-        stops_arr_i_QPair.second = *(stops_arr_i_second[0]);
-        stops_QList.push_back(stops_arr_i_QPair);
-    }
-    self->setStops(stops_QList);
-}
-
 libqt_list /* of libqt_pair  tuple of double and QColor*  */ KGradientSelector_Stops(const KGradientSelector* self) {
     QList<QPair<double, QColor>> _ret = self->stops();
     // Convert QList<> from C++ memory to manually-managed C memory

--- a/src/extras-kwidgetsaddons/libkselector.h
+++ b/src/extras-kwidgetsaddons/libkselector.h
@@ -267,7 +267,6 @@ QMetaObject* KGradientSelector_MetaObject(const KGradientSelector* self);
 void* KGradientSelector_Metacast(KGradientSelector* self, const char* param1);
 int KGradientSelector_Metacall(KGradientSelector* self, int param1, int param2, void** param3);
 libqt_string KGradientSelector_Tr(const char* s);
-void KGradientSelector_SetStops(KGradientSelector* self, const libqt_list /* of libqt_pair  tuple of double and QColor*  */ stops);
 libqt_list /* of libqt_pair  tuple of double and QColor*  */ KGradientSelector_Stops(const KGradientSelector* self);
 void KGradientSelector_SetColors(KGradientSelector* self, const QColor* col1, const QColor* col2);
 void KGradientSelector_SetText(KGradientSelector* self, const libqt_string t1, const libqt_string t2);

--- a/src/extras-kwidgetsaddons/libkselector.zig
+++ b/src/extras-kwidgetsaddons/libkselector.zig
@@ -5641,17 +5641,6 @@ pub const kgradientselector = struct {
         return _ret;
     }
 
-    /// [Qt documentation](https://api.kde.org/kgradientselector.html#setStops)
-    ///
-    /// ``` self: QtC.KGradientSelector, stops: []struct_f64_qtcqcolor ```
-    pub fn SetStops(self: ?*anyopaque, stops: []struct_f64_qtcqcolor) void {
-        const stops_list = qtc.libqt_list{
-            .len = stops.len,
-            .data = stops.ptr,
-        };
-        qtc.KGradientSelector_SetStops(@ptrCast(self), stops_list);
-    }
-
     /// [Qt documentation](https://api.kde.org/kgradientselector.html#stops)
     ///
     /// ``` self: QtC.KGradientSelector, allocator: std.mem.Allocator ```


### PR DESCRIPTION
This is generating an undefined symbol error when linked during compilation.